### PR TITLE
Fixed trigger logic and inverted axis events

### DIFF
--- a/XRTK.Lumin/Packages/com.xrtk.lumin/Controllers/LuminController.cs
+++ b/XRTK.Lumin/Packages/com.xrtk.lumin/Controllers/LuminController.cs
@@ -4,13 +4,13 @@
 using XRTK.Definitions.Devices;
 using XRTK.Definitions.InputSystem;
 using XRTK.Definitions.Utilities;
-using XRTK.Extensions;
 using XRTK.Interfaces.InputSystem;
 using XRTK.Providers.Controllers;
 
 #if PLATFORM_LUMIN
 using UnityEngine;
 using UnityEngine.XR.MagicLeap;
+using XRTK.Extensions;
 using XRTK.Services;
 #endif
 
@@ -202,7 +202,7 @@ namespace XRTK.Lumin.Controllers
                 case DeviceInputType.TriggerTouch:
                 case DeviceInputType.TouchpadTouch:
                 case DeviceInputType.TriggerNearTouch:
-                    interactionMapping.BoolData = interactionMapping.FloatData.Equals(interactionMapping.InvertXAxis ? 1f : 0f);
+                    interactionMapping.BoolData = !interactionMapping.FloatData.Equals(interactionMapping.InvertXAxis ? 1f : 0f);
                     break;
                 default:
                     Debug.LogError($"Input [{interactionMapping.InputType}] is not handled for this controller [{GetType().Name}]");

--- a/XRTK.Lumin/Packages/com.xrtk.lumin/Controllers/LuminController.cs
+++ b/XRTK.Lumin/Packages/com.xrtk.lumin/Controllers/LuminController.cs
@@ -193,18 +193,16 @@ namespace XRTK.Lumin.Controllers
 
             switch (interactionMapping.InputType)
             {
-                case DeviceInputType.Trigger:
-                    // Do nothing.
-                    break;
                 case DeviceInputType.Select:
+                case DeviceInputType.Trigger:
                 case DeviceInputType.TriggerPress:
                 case DeviceInputType.TouchpadPress:
-                    interactionMapping.BoolData = interactionMapping.FloatData.Equals(1f);
+                    interactionMapping.BoolData = interactionMapping.FloatData.Equals(interactionMapping.InvertXAxis ? 0f : 1f);
                     break;
                 case DeviceInputType.TriggerTouch:
                 case DeviceInputType.TouchpadTouch:
                 case DeviceInputType.TriggerNearTouch:
-                    interactionMapping.BoolData = !interactionMapping.FloatData.Equals(0f);
+                    interactionMapping.BoolData = interactionMapping.FloatData.Equals(interactionMapping.InvertXAxis ? 1f : 0f);
                     break;
                 default:
                     Debug.LogError($"Input [{interactionMapping.InputType}] is not handled for this controller [{GetType().Name}]");

--- a/XRTK.Lumin/Packages/com.xrtk.lumin/package.json
+++ b/XRTK.Lumin/Packages/com.xrtk.lumin/package.json
@@ -13,7 +13,7 @@
     "reality",
     "lumin"
   ],
-  "version": "0.1.8",
+  "version": "0.1.9",
   "unity": "2019.1",
   "license": "MIT",
   "src": "Assets/XRTK.Lumin",


### PR DESCRIPTION
## Overview

- Trigger inputs were not raising input up/down events properly.
- Added in better logic for determining the bool data when input axes are inverted.