### PR TITLE
Fixed Trigger Events

### DIFF
--- a/XRTK.Lumin/Packages/com.xrtk.lumin/Controllers/LuminController.cs
+++ b/XRTK.Lumin/Packages/com.xrtk.lumin/Controllers/LuminController.cs
@@ -187,10 +187,6 @@ namespace XRTK.Lumin.Controllers
         {
             Debug.Assert(interactionMapping.AxisType == AxisType.SingleAxis || interactionMapping.AxisType == AxisType.Digital);
 
-            interactionMapping.FloatData = interactionMapping.Description.Contains("Touchpad")
-                ? MlControllerReference.Touch1PosAndForce.z
-                : MlControllerReference.TriggerValue;
-
             switch (interactionMapping.InputType)
             {
                 case DeviceInputType.Select:
@@ -208,6 +204,10 @@ namespace XRTK.Lumin.Controllers
                     Debug.LogError($"Input [{interactionMapping.InputType}] is not handled for this controller [{GetType().Name}]");
                     return;
             }
+
+            interactionMapping.FloatData = interactionMapping.Description.Contains("Touchpad")
+                ? MlControllerReference.Touch1PosAndForce.z
+                : MlControllerReference.TriggerValue;
         }
 
         private void UpdateDualAxisData(MixedRealityInteractionMapping interactionMapping)

--- a/XRTK.Lumin/Packages/com.xrtk.lumin/Controllers/LuminController.cs
+++ b/XRTK.Lumin/Packages/com.xrtk.lumin/Controllers/LuminController.cs
@@ -187,10 +187,14 @@ namespace XRTK.Lumin.Controllers
         {
             Debug.Assert(interactionMapping.AxisType == AxisType.SingleAxis || interactionMapping.AxisType == AxisType.Digital);
 
+            interactionMapping.FloatData = interactionMapping.Description.Contains("Touchpad")
+                ? MlControllerReference.Touch1PosAndForce.z
+                : MlControllerReference.TriggerValue;
+
             switch (interactionMapping.InputType)
             {
-                case DeviceInputType.Select:
                 case DeviceInputType.Trigger:
+                case DeviceInputType.Select:
                 case DeviceInputType.TriggerPress:
                 case DeviceInputType.TouchpadPress:
                     interactionMapping.BoolData = interactionMapping.FloatData.Equals(interactionMapping.InvertXAxis ? 0f : 1f);
@@ -204,10 +208,6 @@ namespace XRTK.Lumin.Controllers
                     Debug.LogError($"Input [{interactionMapping.InputType}] is not handled for this controller [{GetType().Name}]");
                     return;
             }
-
-            interactionMapping.FloatData = interactionMapping.Description.Contains("Touchpad")
-                ? MlControllerReference.Touch1PosAndForce.z
-                : MlControllerReference.TriggerValue;
         }
 
         private void UpdateDualAxisData(MixedRealityInteractionMapping interactionMapping)


### PR DESCRIPTION
## Overview

Fixed an issue where the trigger's interaction mapping updated flag wasn't being reset right after we read the bool data. This would cause the trigger data to only be updated when we got a full press instead of getting all the values in between 0 and 1. Trigger should also raise input up/down events as well.

The order in which the data is read is important when raising the events to the input system.

Likely all controller implementations should set the bool data, then the float data for single axis inputs.
