### PR TITLE
Remove obsolete SetupDefaultInteractions

### DIFF
--- a/XRTK.Lumin/Packages/com.xrtk.lumin/Controllers/LuminController.cs
+++ b/XRTK.Lumin/Packages/com.xrtk.lumin/Controllers/LuminController.cs
@@ -48,12 +48,6 @@ namespace XRTK.Lumin.Controllers
         /// <inheritdoc />
         public override MixedRealityInteractionMapping[] DefaultRightHandedInteractions => DefaultInteractions;
 
-        /// <inheritdoc />
-        public override void SetupDefaultInteractions(Handedness controllerHandedness)
-        {
-            AssignControllerMappings(DefaultInteractions);
-        }
-
 #if PLATFORM_LUMIN
 
         internal MLInputController MlControllerReference { get; set; }


### PR DESCRIPTION
## Overview

Removes the obsolete `SetupDefaultInteractions` in `BaseController` since it's not run anywhere anymore.