### PR TITLE
Update default near clip plane

### DIFF
--- a/XRTK.Lumin/Packages/com.xrtk.lumin/Profiles~/CameraSystem/LuminCameraDataProvider.asset
+++ b/XRTK.Lumin/Packages/com.xrtk.lumin/Profiles~/CameraSystem/LuminCameraDataProvider.asset
@@ -17,7 +17,7 @@ MonoBehaviour:
   cameraClearFlagsOpaqueDisplay: 1
   backgroundColorOpaqueDisplay: {r: 0, g: 0, b: 0, a: 1}
   opaqueQualityLevel: 0
-  nearClipPlaneTransparentDisplay: 0.1
+  nearClipPlaneTransparentDisplay: 0.2
   cameraClearFlagsTransparentDisplay: 2
   backgroundColorTransparentDisplay: {r: 0, g: 0, b: 0, a: 0}
   transparentQualityLevel: 0


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

Updates the Lumin default near clip plane distance to 0.2 for transparent displays.
