### PR TITLE
Fix using statement compiler error

### DIFF
--- a/XRTK.Lumin/Packages/com.xrtk.lumin/Runtime/Native/AssemblyInfo.cs
+++ b/XRTK.Lumin/Packages/com.xrtk.lumin/Runtime/Native/AssemblyInfo.cs
@@ -1,7 +1,11 @@
-﻿// Copyright (c) XRTK. All rights reserved.
+// Copyright (c) XRTK. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System.Runtime.CompilerServices;
+using System.Reflection;
 
 [assembly: InternalsVisibleTo("XRTK.Lumin")]
 [assembly: InternalsVisibleTo("XRTK.Lumin.Editor")]
+
+[assembly: AssemblyVersion("0.2.10")]
+[assembly: AssemblyTitle("com.xrtk.lumin.native")]


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

Fix

`Packages\com.xrtk.lumin\Runtime\Native\AssemblyInfo.cs(9,1): error CS1529: A using clause must precede all other elements defined in the namespace except extern alias declarations
`

error preventing project from compiling.
