### PR TITLE
Enable Camera System to work with XR SDK / 2020.1 and above

### DIFF
--- a/XRTK.Lumin/Packages/com.xrtk.lumin/Profiles~/CameraSystem/LuminCameraDataProvider.asset
+++ b/XRTK.Lumin/Packages/com.xrtk.lumin/Profiles~/CameraSystem/LuminCameraDataProvider.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 00d813fd5a164e19a160f322b2926006, type: 3}
   m_Name: LuminCameraDataProvider
   m_EditorClassIdentifier: 
+  trackingOriginMode: 1
   isCameraPersistent: 1
   nearClipPlaneOpaqueDisplay: 0.1
   cameraClearFlagsOpaqueDisplay: 1

--- a/XRTK.Lumin/Packages/com.xrtk.lumin/Runtime/Providers/CameraSystem/LuminCameraDataProvider.cs
+++ b/XRTK.Lumin/Packages/com.xrtk.lumin/Runtime/Providers/CameraSystem/LuminCameraDataProvider.cs
@@ -26,23 +26,6 @@ namespace XRTK.Lumin.Providers.CameraSystem
         /// <inheritdoc />
         public override bool IsOpaque => false;
 
-        private float headHeight;
-
-        /// <inheritdoc />
-        public override float HeadHeight
-        {
-            get => headHeight;
-            set
-            {
-                if (value.Equals(headHeight))
-                {
-                    return;
-                }
-
-                headHeight = value;
-            }
-        }
-
         /// <inheritdoc />
         protected override void ResetRigTransforms()
         {

--- a/XRTK.Lumin/Packages/com.xrtk.lumin/Runtime/Providers/CameraSystem/LuminCameraDataProvider.cs
+++ b/XRTK.Lumin/Packages/com.xrtk.lumin/Runtime/Providers/CameraSystem/LuminCameraDataProvider.cs
@@ -26,6 +26,25 @@ namespace XRTK.Lumin.Providers.CameraSystem
         /// <inheritdoc />
         public override bool IsOpaque => false;
 
+#if XRTK_USE_LEGACYVR
+        private float headHeight;
+
+        /// <inheritdoc />
+        public override float HeadHeight
+        {
+            get => headHeight;
+            set
+            {
+                if (value.Equals(headHeight))
+                {
+                    return;
+                }
+
+                headHeight = value;
+            }
+        }
+#endif
+
         /// <inheritdoc />
         protected override void ResetRigTransforms()
         {


### PR DESCRIPTION
# XRTK - Mixed Reality Toolkit Pull Request

## Overview

Lumin specific changes for https://github.com/XRTK/com.xrtk.core/pull/897

## Changes

- Updated camera data provider profile to default to Device tracking space which is the best setting for Magic Leap devices
- Put some obsolete code behind a scripting define symbol

## Related Submodule Changes

- https://github.com/XRTK/com.xrtk.core/pull/897
- https://github.com/XRTK/com.xrtk.wmr/pull/148
- https://github.com/XRTK/com.xrtk.sdk/pull/247
- https://github.com/XRTK/com.xrtk.oculus/pull/134
